### PR TITLE
fix: add missing 'location' for container registry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ module "registry" {
   source       = "github.com/chrismellard/terraform-jx-registry-acr?ref=main"
   cluster_name = local.cluster_name
   principal_id = module.cluster.kubelet_identity_id
+  location     = var.location
 }
 
 module "jx-boot" {


### PR DESCRIPTION
Without it, all container registries are located in Australia East even if we specify another location in variables.auto.tfvars